### PR TITLE
perf: set explicit Timeout on the connector's http.Client

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -95,7 +96,7 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 // New returns a new instance of the connector.
 func New(ctx context.Context, apiUrl string, token string) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
-	httpClient := uhttp.NewBaseHttpClient(&http.Client{})
+	httpClient := uhttp.NewBaseHttpClient(&http.Client{Timeout: 30 * time.Second})
 	zuperClient, err := client.New(ctx, client.NewClient(ctx, apiUrl, token, httpClient))
 	if err != nil {
 		l.Error("error creating Zuper client", zap.Error(err))


### PR DESCRIPTION
The baseline \`*http.Client\` constructed in \`connector.New\` had no \`Timeout\`, so a hung upstream stalls the request indefinitely. \`uhttp.NewBaseHttpClient\` wraps the client with transport-level timeouts (TLSHandshakeTimeout, ResponseHeaderTimeout) but does not set the overall request \`Timeout\`. Without the per-request bound, an attacker- or accident-induced slowloris keeps the goroutine alive past every transport-level deadline.

Added a 30s \`Timeout\` matching the baton-sdk \`uhttp\` transport defaults.

How found: occult-go-analysis baton pool scan (2026-05-20), detector \`http_client_literal_without_timeout\`.