### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/access_role.go
+++ b/pkg/connector/access_role.go
@@ -105,7 +105,8 @@ func (b *accessRoleBuilder) List(ctx context.Context, parentResourceID *v2.Resou
 			role.AccessRoleName,
 			b.resourceType,
 			uid,
-			[]resource.RoleTraitOption{resource.WithRoleProfile(profile)},
+			[]resource.RoleTraitOption{},
+			resource.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, "", annos, fmt.Errorf("failed to create access role resource: %w", err)

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -56,7 +56,8 @@ func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 			role.DisplayName,
 			r.resourceType,
 			role.RoleKey,
-			[]resource.RoleTraitOption{resource.WithRoleProfile(profile)},
+			[]resource.RoleTraitOption{},
+			resource.WithResourceProfile(profile),
 		)
 		if err != nil {
 			return nil, "", annos, fmt.Errorf("failed to create role resource: %w", err)

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -51,9 +51,8 @@ func parseIntoTeamResource(team *client.Team) (*v2.Resource, error) {
 		team.TeamName,
 		teamResourceType,
 		team.TeamUID,
-		[]resource.GroupTraitOption{
-			resource.WithGroupProfile(profile),
-		},
+		[]resource.GroupTraitOption{},
+		resource.WithResourceProfile(profile),
 	)
 }
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -206,8 +206,6 @@ func parseIntoUserResource(user *client.ZuperUser) (*v2.Resource, error) {
 	}
 
 	userTraits := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
-		resource.WithStatus(userStatus),
 		resource.WithUserLogin(user.Email),
 		resource.WithEmail(user.Email, true),
 	}
@@ -218,6 +216,8 @@ func parseIntoUserResource(user *client.ZuperUser) (*v2.Resource, error) {
 		userResourceType,
 		user.UserUID,
 		userTraits,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
